### PR TITLE
Deleting old Tagesangebote

### DIFF
--- a/php/dependencies.php
+++ b/php/dependencies.php
@@ -12,8 +12,11 @@
 		die("Connection failed: " . $conn->connect_error);
 	}
 
-		$conn->query("SET NAMES 'utf8'");//Für korrekte Ausgabe der Umlaute;
+		$conn->query("SET CHARSET 'utf8'");//Für korrekte Ausgabe der Umlaute;
+		$expireDate = date("Y-m-d", strtotime("-21 day"));
+		$deleteOldTagesangebote = "DELETE FROM mensa.tagesangebot WHERE datum <= '$expireDate'";
 
+		$conn->query($deleteOldTagesangebote); //Löscht alle Einträge,die Älter als 3 Wochen sind(21 tage)
 
 	$head_dependencies = '
 		 <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
@@ -31,7 +34,7 @@
 		<script src="../vendor/bootstrap/js/bootstrap.min.js"></script>
 		<script src="../vendor/tether/js/tether.min.js"></script>
 
-		
+
 ';
 
 

--- a/php/index.php
+++ b/php/index.php
@@ -47,7 +47,7 @@
 			<div class="row">
 				<div class="col-sm-1">
 				 <?PHP  $ThreeWeeksAgo = date("W", strtotime("- 3 week")); //Current week -3 ?>
-					<a href="<?php echo $_SERVER['PHP_SELF'].'?week='.($week == 1 ? 52 : $week -1).'&year='.($week == 1 ? $year - 1 : $year); if($week == $ThreeWeeksAgo) { echo "class= 'disable'"; } //if we reach the week 3 weeks ago, than the link is disabled ?>">
+					<a href="<?php echo $_SERVER['PHP_SELF'].'?week='.($week == 1 ? 52 : $week -1).'&year='.($week == 1 ? $year - 1 : $year) . '"'; if($week <= $ThreeWeeksAgo) { echo " class='disable' "; } //if we reach the week 3 weeks ago, than the link is disabled ?>">
 					<button class="btn btn-success index-btns" <?PHP if($week == $ThreeWeeksAgo) { echo "disabled"; } //if we reach the week 3 weeks ago, than the button is disabled ?> >
 						<i class='fas fa-chevron-circle-left'> </i>
 					</button></a> <!--Button um eine Woche zurück zu springen -->

--- a/php/index.php
+++ b/php/index.php
@@ -46,8 +46,9 @@
 		<div class="container">
 			<div class="row">
 				<div class="col-sm-1">
-					<a href="<?php echo $_SERVER['PHP_SELF'].'?week='.($week == 1 ? 52 : $week -1).'&year='.($week == 1 ? $year - 1 : $year); ?>">
-					<button class="btn btn-success index-btns">
+				 <?PHP  $ThreeWeeksAgo = date("W", strtotime("- 3 week")); //Current week -3 ?>
+					<a href="<?php echo $_SERVER['PHP_SELF'].'?week='.($week == 1 ? 52 : $week -1).'&year='.($week == 1 ? $year - 1 : $year); if($week == $ThreeWeeksAgo) { echo "class= 'disable'"; } //if we reach the week 3 weeks ago, than the link is disabled ?>">
+					<button class="btn btn-success index-btns" <?PHP if($week == $ThreeWeeksAgo) { echo "disabled"; } //if we reach the week 3 weeks ago, than the button is disabled ?> >
 						<i class='fas fa-chevron-circle-left'> </i>
 					</button></a> <!--Button um eine Woche zurück zu springen -->
 				</div>

--- a/style/style.css
+++ b/style/style.css
@@ -42,7 +42,7 @@ body {
 
 .alert {
   position: relative;
-  z-index: 999999;
+  z-index: 1039;
   left: 0;
   right: 0;
   margin-left: auto;

--- a/style/style.css
+++ b/style/style.css
@@ -97,6 +97,11 @@ body {
   background-color: #eee!important;
 }
 
+.disable {
+  pointer-events: none;
+  cursor: default;
+}
+
 .dropdown {
 	margin-right: 15px;
 }


### PR DESCRIPTION
So from now on all Tagesangebote, which are older than 3Weeks(21 days) will be deleted automatically to save database Place and that way the pages will remain loading faster. If you guys want we can change it to a longer period.

## **How to test**:

1. Comment out the query. It should be like this:
```
$deleteOldTagesangebote = "DELETE FROM mensa.tagesangebot WHERE datum <= '$expireDate'";

		//$conn->query($deleteOldTagesangebote); //Löscht alle Einträge,die Älter als 3 Wochen sind(21 tage)
```

2. Add Tagesangebote which are more than 3 weeks ago and some in this week.
3. Open MySQL Workbench and Select all from Tagesangebote
4. Uncomment the query
5. In MySQL select all Tagesangebote again -> You'll see that all records, that are older than 21days are deleted.